### PR TITLE
Add dynamic HDRP component registry and runtime UI controls

### DIFF
--- a/Documentation/HDRP_Dynamic_Modularization_Review.md
+++ b/Documentation/HDRP_Dynamic_Modularization_Review.md
@@ -1,0 +1,104 @@
+# HDRP Dynamic Modularization Review
+
+## Code check summary
+
+### What was run
+- `dotnet build Lumina.sln -c Release`
+- `npm ci` (in `Lumina/`)
+- `npm run build` (in `Lumina/`)
+- `npx tsc --noEmit` (in `Lumina/`)
+
+### Results
+- `dotnet build Lumina.sln -c Release` could not run in this environment because `dotnet` is not installed.
+- `npm ci` completed successfully.
+- `npm run build` failed because `CSII_USERDATAPATH` is not set in the environment.
+- `npx tsc --noEmit` completed successfully.
+
+## Findings: why HDRP controls are not yet fully dynamic
+
+The current architecture already exposes many HDRP controls, but they are assembled as a mostly hardcoded set of feature paths.
+
+1. **Render update path is centralized and fixed**  
+   `RenderEffectsSystem.OnUpdate` calls component handlers directly (`ColorAdjustments`, `WhiteBalance`, `ShadowsMidTonesHighlights`) each update loop, which makes growth more manual than declarative.
+
+2. **UI binding registration is very large and static**  
+   `UISystem.CreateBindings` manually registers a long list of sliders, toggles, and actions. This is powerful but means every new component requires touching core binding code.
+
+3. **Configuration is property-per-feature**  
+   `GlobalVariables` stores many explicit XML fields for each control. This is easy to debug, but extending to many additional HDRP components can become expensive in maintenance and migration.
+
+## Suggestions: making HDRP component selection customer-driven
+
+### 1) Introduce a component registry (first step)
+Create a registry that declares each controllable HDRP feature as metadata, for example:
+
+- `ComponentId` (`"colorAdjustments"`, `"whiteBalance"`, etc.)
+- `VolumeComponentType` (`ColorAdjustments`, `WhiteBalance`, ...)
+- `DisplayName`
+- `Category` (Color, Lighting, Atmosphere, Post)
+- `DefaultEnabled`
+- `PropertyDescriptors` (name, type, min/max, default)
+
+This allows customer-facing UI to render from data instead of hardcoded per-component UI blocks.
+
+### 2) Add per-component enablement in persisted settings
+Add a dictionary-style persisted setting such as:
+
+- `Dictionary<string, bool> EnabledComponents`
+- (optional) `Dictionary<string, Dictionary<string, object>> ComponentOverrides`
+
+Keep existing fields for backward compatibility initially, then gradually migrate.
+
+### 3) Refactor runtime updates to strategy handlers
+Replace direct monolithic calls with handlers implementing a shared interface, e.g.:
+
+- `IHdrpComponentHandler.Initialize(volumeProfile)`
+- `IHdrpComponentHandler.Apply(settingsSnapshot)`
+- `IHdrpComponentHandler.ResetToDefault()`
+
+The main render system loops registered handlers and only executes enabled components.
+
+### 4) Generate UI bindings from descriptors
+In `UISystem`, generate bindings from registry descriptors:
+
+- auto-create getter/setter binding names
+- auto-wire slider ranges and checkbox state
+- hide disabled components by policy/profile
+
+This is the key to allowing customers to choose which component categories are shown/active.
+
+### 5) Add customer profiles / presets by component groups
+Support profiles such as:
+
+- **Performance Profile** (minimal effects)
+- **Cinematic Profile** (full effects)
+- **Colorist Profile** (color stack only)
+
+Each profile is a predefined set of enabled component IDs plus defaults.
+
+### 6) Compatibility and safety gates
+Before enabling a component at runtime, gate by:
+
+- game version support
+- installed incompatible mods
+- GPU tier/performance mode
+
+This aligns with existing compatibility checks and avoids user-exposed controls that cannot run safely on certain setups.
+
+### 7) Migration plan (low risk)
+1. Introduce registry + handlers for existing 3 core components.
+2. Keep old fields and map them into new internal model.
+3. Convert UI binding for one section (e.g., White Balance) to generated mode.
+4. Expand to tonemapping, sky, and clouds.
+5. Deprecate duplicated hardcoded paths.
+
+## Practical next milestone
+
+A pragmatic first deliverable:
+
+- Add component registry classes.
+- Register current components (`ColorAdjustments`, `WhiteBalance`, `ShadowsMidtonesHighlights`).
+- Add persisted `EnabledComponents` with defaults set to current behavior.
+- Render one dynamic UI section from descriptors.
+
+This would prove the pattern while keeping current behavior stable.

--- a/Systems/DynamicHdrp/DynamicHdrpContracts.cs
+++ b/Systems/DynamicHdrp/DynamicHdrpContracts.cs
@@ -1,0 +1,170 @@
+namespace Lumina.Systems.DynamicHdrp
+{
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Text;
+
+    internal enum DynamicHdrpPropertyType
+    {
+        Float,
+        Bool,
+    }
+
+    internal sealed class DynamicHdrpPropertyDescriptor
+    {
+        public string Id { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public DynamicHdrpPropertyType Type { get; set; }
+
+        public float Min { get; set; }
+
+        public float Max { get; set; }
+
+        public float Step { get; set; }
+    }
+
+    internal sealed class DynamicHdrpComponentDescriptor
+    {
+        public string Id { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public string Category { get; set; }
+
+        public bool DefaultEnabled { get; set; }
+
+        public List<DynamicHdrpPropertyDescriptor> Properties { get; set; } = new List<DynamicHdrpPropertyDescriptor>();
+    }
+
+    internal static class DynamicHdrpJson
+    {
+        public static string BuildMetadataJson(IEnumerable<DynamicHdrpComponentDescriptor> components)
+        {
+            var sb = new StringBuilder();
+            sb.Append("[");
+
+            bool isFirst = true;
+            foreach (var component in components)
+            {
+                if (!isFirst)
+                {
+                    sb.Append(",");
+                }
+
+                isFirst = false;
+                sb.Append("{");
+                sb.Append("\"id\":\"").Append(Escape(component.Id)).Append("\",");
+                sb.Append("\"displayName\":\"").Append(Escape(component.DisplayName)).Append("\",");
+                sb.Append("\"category\":\"").Append(Escape(component.Category)).Append("\",");
+                sb.Append("\"defaultEnabled\":").Append(component.DefaultEnabled ? "true" : "false").Append(",");
+                sb.Append("\"properties\":[");
+
+                for (int i = 0; i < component.Properties.Count; i++)
+                {
+                    var property = component.Properties[i];
+                    if (i > 0)
+                    {
+                        sb.Append(",");
+                    }
+
+                    sb.Append("{");
+                    sb.Append("\"id\":\"").Append(Escape(property.Id)).Append("\",");
+                    sb.Append("\"displayName\":\"").Append(Escape(property.DisplayName)).Append("\",");
+                    sb.Append("\"type\":\"").Append(property.Type == DynamicHdrpPropertyType.Float ? "float" : "bool").Append("\",");
+                    sb.Append("\"min\":").Append(property.Min.ToString(CultureInfo.InvariantCulture)).Append(",");
+                    sb.Append("\"max\":").Append(property.Max.ToString(CultureInfo.InvariantCulture)).Append(",");
+                    sb.Append("\"step\":").Append(property.Step.ToString(CultureInfo.InvariantCulture));
+                    sb.Append("}");
+                }
+
+                sb.Append("]");
+                sb.Append("}");
+            }
+
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        public static string BuildStateJson(IEnumerable<DynamicHdrpComponentRuntimeState> state)
+        {
+            var sb = new StringBuilder();
+            sb.Append("[");
+
+            bool isFirst = true;
+            foreach (var component in state)
+            {
+                if (!isFirst)
+                {
+                    sb.Append(",");
+                }
+
+                isFirst = false;
+                sb.Append("{");
+                sb.Append("\"componentId\":\"").Append(Escape(component.ComponentId)).Append("\",");
+                sb.Append("\"enabled\":").Append(component.Enabled ? "true" : "false").Append(",");
+                sb.Append("\"values\":{");
+
+                int propertyCounter = 0;
+                foreach (var kvp in component.Values)
+                {
+                    if (propertyCounter > 0)
+                    {
+                        sb.Append(",");
+                    }
+
+                    propertyCounter++;
+                    sb.Append("\"").Append(Escape(kvp.Key)).Append("\":");
+
+                    if (kvp.Value is bool boolValue)
+                    {
+                        sb.Append(boolValue ? "true" : "false");
+                    }
+                    else if (kvp.Value is float floatValue)
+                    {
+                        sb.Append(floatValue.ToString(CultureInfo.InvariantCulture));
+                    }
+                    else if (kvp.Value is int intValue)
+                    {
+                        sb.Append(intValue.ToString(CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append("\"").Append(Escape(kvp.Value?.ToString() ?? string.Empty)).Append("\"");
+                    }
+                }
+
+                sb.Append("}");
+                sb.Append("}");
+            }
+
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        private static string Escape(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
+            return input
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("\n", "\\n")
+                .Replace("\r", "\\r")
+                .Replace("\t", "\\t");
+        }
+    }
+
+    internal sealed class DynamicHdrpComponentRuntimeState
+    {
+        public string ComponentId { get; set; }
+
+        public bool Enabled { get; set; }
+
+        public Dictionary<string, object> Values { get; set; } = new Dictionary<string, object>();
+    }
+}

--- a/Systems/DynamicHdrp/DynamicHdrpModules.cs
+++ b/Systems/DynamicHdrp/DynamicHdrpModules.cs
@@ -1,0 +1,256 @@
+namespace Lumina.Systems.DynamicHdrp
+{
+    using System;
+    using System.Collections.Generic;
+    using LuminaMod.XML;
+    using UnityEngine;
+    using UnityEngine.Rendering;
+    using UnityEngine.Rendering.HighDefinition;
+
+    internal interface IDynamicHdrpComponentModule
+    {
+        DynamicHdrpComponentDescriptor Descriptor { get; }
+
+        bool IsEnabled { get; }
+
+        void Initialize(VolumeProfile profile);
+
+        void SetEnabled(bool enabled);
+
+        void Apply(GlobalVariables settings);
+
+        Dictionary<string, object> GetCurrentValues(GlobalVariables settings);
+
+        bool TrySetValue(string propertyId, string value);
+    }
+
+    internal abstract class DynamicHdrpComponentModuleBase<TComponent> : IDynamicHdrpComponentModule
+        where TComponent : VolumeComponent
+    {
+        private readonly Dictionary<string, Func<GlobalVariables, object>> m_Readers = new Dictionary<string, Func<GlobalVariables, object>>();
+        private readonly Dictionary<string, Action<string>> m_Writers = new Dictionary<string, Action<string>>();
+
+        protected TComponent Component;
+
+        protected DynamicHdrpComponentModuleBase(DynamicHdrpComponentDescriptor descriptor)
+        {
+            Descriptor = descriptor;
+            IsEnabled = descriptor.DefaultEnabled;
+        }
+
+        public DynamicHdrpComponentDescriptor Descriptor { get; }
+
+        public bool IsEnabled { get; private set; }
+
+        public void Initialize(VolumeProfile profile)
+        {
+            if (!profile.TryGet(out Component))
+            {
+                Component = profile.Add<TComponent>();
+            }
+
+            Component.active = IsEnabled;
+        }
+
+        public void SetEnabled(bool enabled)
+        {
+            IsEnabled = enabled;
+            if (Component != null)
+            {
+                Component.active = enabled;
+            }
+        }
+
+        public void Apply(GlobalVariables settings)
+        {
+            if (Component == null)
+            {
+                return;
+            }
+
+            Component.active = IsEnabled;
+            if (!IsEnabled)
+            {
+                return;
+            }
+
+            ApplyInternal(settings);
+        }
+
+        public Dictionary<string, object> GetCurrentValues(GlobalVariables settings)
+        {
+            var values = new Dictionary<string, object>();
+            foreach (var descriptor in Descriptor.Properties)
+            {
+                if (m_Readers.TryGetValue(descriptor.Id, out var reader))
+                {
+                    values[descriptor.Id] = reader(settings);
+                }
+            }
+
+            return values;
+        }
+
+        public bool TrySetValue(string propertyId, string value)
+        {
+            if (!m_Writers.TryGetValue(propertyId, out var writer))
+            {
+                return false;
+            }
+
+            writer(value);
+            return true;
+        }
+
+        protected void RegisterFloat(string propertyId, Func<GlobalVariables, float> reader, Action<float> writer)
+        {
+            m_Readers[propertyId] = settings => reader(settings);
+            m_Writers[propertyId] = raw =>
+            {
+                if (float.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+                {
+                    writer(parsed);
+                }
+            };
+        }
+
+        protected void RegisterBool(string propertyId, Func<GlobalVariables, bool> reader, Action<bool> writer)
+        {
+            m_Readers[propertyId] = settings => reader(settings);
+            m_Writers[propertyId] = raw =>
+            {
+                if (bool.TryParse(raw, out var parsed))
+                {
+                    writer(parsed);
+                }
+                else if (raw == "1")
+                {
+                    writer(true);
+                }
+                else if (raw == "0")
+                {
+                    writer(false);
+                }
+            };
+        }
+
+        protected abstract void ApplyInternal(GlobalVariables settings);
+    }
+
+    internal sealed class ColorAdjustmentsModule : DynamicHdrpComponentModuleBase<ColorAdjustments>
+    {
+        public ColorAdjustmentsModule()
+            : base(new DynamicHdrpComponentDescriptor
+            {
+                Id = "colorAdjustments",
+                DisplayName = "Color Adjustments",
+                Category = "Color",
+                DefaultEnabled = true,
+                Properties = new List<DynamicHdrpPropertyDescriptor>
+                {
+                    new DynamicHdrpPropertyDescriptor { Id = "postExposure", DisplayName = "Post Exposure", Type = DynamicHdrpPropertyType.Float, Min = -1f, Max = 1f, Step = 0.0001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "postExposureActive", DisplayName = "Post Exposure Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                    new DynamicHdrpPropertyDescriptor { Id = "contrast", DisplayName = "Contrast", Type = DynamicHdrpPropertyType.Float, Min = -100f, Max = 100f, Step = 0.001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "contrastActive", DisplayName = "Contrast Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                    new DynamicHdrpPropertyDescriptor { Id = "hueShift", DisplayName = "Hue Shift", Type = DynamicHdrpPropertyType.Float, Min = -100f, Max = 100f, Step = 0.001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "hueShiftActive", DisplayName = "Hue Shift Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                    new DynamicHdrpPropertyDescriptor { Id = "saturation", DisplayName = "Saturation", Type = DynamicHdrpPropertyType.Float, Min = -100f, Max = 100f, Step = 0.001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "saturationActive", DisplayName = "Saturation Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                },
+            })
+        {
+            RegisterFloat("postExposure", settings => settings.PostExposure, value => GlobalVariables.Instance.PostExposure = value);
+            RegisterBool("postExposureActive", settings => settings.PostExposureActive, value => GlobalVariables.Instance.PostExposureActive = value);
+            RegisterFloat("contrast", settings => settings.Contrast, value => GlobalVariables.Instance.Contrast = value);
+            RegisterBool("contrastActive", settings => settings.ContrastActive, value => GlobalVariables.Instance.ContrastActive = value);
+            RegisterFloat("hueShift", settings => settings.HueShift, value => GlobalVariables.Instance.HueShift = value);
+            RegisterBool("hueShiftActive", settings => settings.HueShiftActive, value => GlobalVariables.Instance.HueShiftActive = value);
+            RegisterFloat("saturation", settings => settings.Saturation, value => GlobalVariables.Instance.Saturation = value);
+            RegisterBool("saturationActive", settings => settings.SaturationActive, value => GlobalVariables.Instance.SaturationActive = value);
+        }
+
+        protected override void ApplyInternal(GlobalVariables settings)
+        {
+            Component.postExposure.Override(settings.PostExposure);
+            Component.postExposure.overrideState = settings.PostExposureActive;
+            Component.contrast.Override(settings.Contrast);
+            Component.contrast.overrideState = settings.ContrastActive;
+            Component.hueShift.Override(settings.HueShift);
+            Component.hueShift.overrideState = settings.HueShiftActive;
+            Component.saturation.Override(settings.Saturation);
+            Component.saturation.overrideState = settings.SaturationActive;
+        }
+    }
+
+    internal sealed class WhiteBalanceModule : DynamicHdrpComponentModuleBase<WhiteBalance>
+    {
+        public WhiteBalanceModule()
+            : base(new DynamicHdrpComponentDescriptor
+            {
+                Id = "whiteBalance",
+                DisplayName = "White Balance",
+                Category = "Color",
+                DefaultEnabled = true,
+                Properties = new List<DynamicHdrpPropertyDescriptor>
+                {
+                    new DynamicHdrpPropertyDescriptor { Id = "temperature", DisplayName = "Temperature", Type = DynamicHdrpPropertyType.Float, Min = -100f, Max = 100f, Step = 0.001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "temperatureActive", DisplayName = "Temperature Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                    new DynamicHdrpPropertyDescriptor { Id = "tint", DisplayName = "Tint", Type = DynamicHdrpPropertyType.Float, Min = -100f, Max = 100f, Step = 0.001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "tintActive", DisplayName = "Tint Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                },
+            })
+        {
+            RegisterFloat("temperature", settings => settings.Temperature, value => GlobalVariables.Instance.Temperature = value);
+            RegisterBool("temperatureActive", settings => settings.TemperatureActive, value => GlobalVariables.Instance.TemperatureActive = value);
+            RegisterFloat("tint", settings => settings.Tint, value => GlobalVariables.Instance.Tint = value);
+            RegisterBool("tintActive", settings => settings.TintActive, value => GlobalVariables.Instance.TintActive = value);
+        }
+
+        protected override void ApplyInternal(GlobalVariables settings)
+        {
+            Component.temperature.Override(settings.Temperature);
+            Component.temperature.overrideState = settings.TemperatureActive;
+            Component.tint.Override(settings.Tint);
+            Component.tint.overrideState = settings.TintActive;
+        }
+    }
+
+    internal sealed class ShadowsMidtonesHighlightsModule : DynamicHdrpComponentModuleBase<ShadowsMidtonesHighlights>
+    {
+        public ShadowsMidtonesHighlightsModule()
+            : base(new DynamicHdrpComponentDescriptor
+            {
+                Id = "shadowsMidtonesHighlights",
+                DisplayName = "Shadows Midtones Highlights",
+                Category = "Color",
+                DefaultEnabled = true,
+                Properties = new List<DynamicHdrpPropertyDescriptor>
+                {
+                    new DynamicHdrpPropertyDescriptor { Id = "shadows", DisplayName = "Shadows", Type = DynamicHdrpPropertyType.Float, Min = -1f, Max = 2f, Step = 0.001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "shadowsActive", DisplayName = "Shadows Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                    new DynamicHdrpPropertyDescriptor { Id = "midtones", DisplayName = "Midtones", Type = DynamicHdrpPropertyType.Float, Min = -1f, Max = 2f, Step = 0.001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "midtonesActive", DisplayName = "Midtones Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                    new DynamicHdrpPropertyDescriptor { Id = "highlights", DisplayName = "Highlights", Type = DynamicHdrpPropertyType.Float, Min = -1f, Max = 2f, Step = 0.001f },
+                    new DynamicHdrpPropertyDescriptor { Id = "highlightsActive", DisplayName = "Highlights Enabled", Type = DynamicHdrpPropertyType.Bool, Min = 0f, Max = 1f, Step = 1f },
+                },
+            })
+        {
+            RegisterFloat("shadows", settings => settings.Shadows, value => GlobalVariables.Instance.Shadows = value);
+            RegisterBool("shadowsActive", settings => settings.ShadowsActive, value => GlobalVariables.Instance.ShadowsActive = value);
+            RegisterFloat("midtones", settings => settings.Midtones, value => GlobalVariables.Instance.Midtones = value);
+            RegisterBool("midtonesActive", settings => settings.MidtonesActive, value => GlobalVariables.Instance.MidtonesActive = value);
+            RegisterFloat("highlights", settings => settings.Highlights, value => GlobalVariables.Instance.Highlights = value);
+            RegisterBool("highlightsActive", settings => settings.HighlightsActive, value => GlobalVariables.Instance.HighlightsActive = value);
+        }
+
+        protected override void ApplyInternal(GlobalVariables settings)
+        {
+            Component.shadows.Override(new Vector4(settings.Shadows, settings.Shadows, settings.Shadows, settings.Shadows));
+            Component.shadows.overrideState = settings.ShadowsActive;
+            Component.midtones.Override(new Vector4(settings.Midtones, settings.Midtones, settings.Midtones, settings.Midtones));
+            Component.midtones.overrideState = settings.MidtonesActive;
+            Component.highlights.Override(new Vector4(settings.Highlights, settings.Highlights, settings.Highlights, settings.Highlights));
+            Component.highlights.overrideState = settings.HighlightsActive;
+        }
+    }
+}

--- a/Systems/DynamicHdrp/DynamicHdrpRegistry.cs
+++ b/Systems/DynamicHdrp/DynamicHdrpRegistry.cs
@@ -1,0 +1,100 @@
+namespace Lumina.Systems.DynamicHdrp
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Lumina.XML;
+    using LuminaMod.XML;
+    using UnityEngine.Rendering;
+
+    internal sealed class DynamicHdrpRegistry
+    {
+        private readonly Dictionary<string, IDynamicHdrpComponentModule> m_Modules;
+
+        public DynamicHdrpRegistry(IEnumerable<IDynamicHdrpComponentModule> modules)
+        {
+            m_Modules = modules.ToDictionary(module => module.Descriptor.Id, module => module, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public void Initialize(VolumeProfile profile)
+        {
+            foreach (var module in m_Modules.Values)
+            {
+                module.Initialize(profile);
+                module.SetEnabled(GetStoredEnabledState(module.Descriptor.Id, module.Descriptor.DefaultEnabled));
+            }
+        }
+
+        public void Apply(GlobalVariables settings)
+        {
+            foreach (var module in m_Modules.Values)
+            {
+                module.Apply(settings);
+            }
+        }
+
+        public string GetMetadataJson()
+        {
+            return DynamicHdrpJson.BuildMetadataJson(m_Modules.Values.Select(module => module.Descriptor));
+        }
+
+        public string GetStateJson(GlobalVariables settings)
+        {
+            var state = m_Modules.Values.Select(module => new DynamicHdrpComponentRuntimeState
+            {
+                ComponentId = module.Descriptor.Id,
+                Enabled = module.IsEnabled,
+                Values = module.GetCurrentValues(settings),
+            });
+
+            return DynamicHdrpJson.BuildStateJson(state);
+        }
+
+        public void SetComponentEnabled(string componentId, bool enabled)
+        {
+            if (!m_Modules.TryGetValue(componentId, out var module))
+            {
+                Mod.Log.Info($"[LUMINA-DYNAMIC] Unknown component id '{componentId}'.");
+                return;
+            }
+
+            module.SetEnabled(enabled);
+            GlobalVariables.Instance.SetDynamicComponentState(componentId, enabled);
+
+            if (GlobalVariables.Instance.SaveAutomatically)
+            {
+                GlobalVariables.SaveToFile(GlobalPaths.GlobalModSavingPath);
+            }
+        }
+
+        public void SetPropertyValue(string componentId, string propertyId, string value)
+        {
+            if (!m_Modules.TryGetValue(componentId, out var module))
+            {
+                return;
+            }
+
+            if (!module.TrySetValue(propertyId, value))
+            {
+                return;
+            }
+
+            if (GlobalVariables.Instance.SaveAutomatically)
+            {
+                GlobalVariables.SaveToFile(GlobalPaths.GlobalModSavingPath);
+            }
+        }
+
+        private static bool GetStoredEnabledState(string componentId, bool defaultValue)
+        {
+            bool? stored = GlobalVariables.Instance.GetDynamicComponentState(componentId);
+            if (!stored.HasValue)
+            {
+                GlobalVariables.Instance.SetDynamicComponentState(componentId, defaultValue);
+                return defaultValue;
+            }
+
+            return stored.Value;
+        }
+    }
+}

--- a/Systems/UISystem.cs
+++ b/Systems/UISystem.cs
@@ -73,6 +73,7 @@
             UseLuminaVolume();
             Checkboxes();
             ColorAdjustments();
+            DynamicHdrpBindings();
 
             WhiteBalance();
             WhiteBalanceCheckboxes();
@@ -213,6 +214,57 @@
             AddSupportBindings();
          
 
+        }
+
+        private void DynamicHdrpBindings()
+        {
+            AddUpdateBinding(new GetterValueBinding<string>(Mod.MODUI, "DynamicHdrpMetadata", GetDynamicHdrpMetadata));
+            AddUpdateBinding(new GetterValueBinding<string>(Mod.MODUI, "DynamicHdrpState", GetDynamicHdrpState));
+            AddBinding(new TriggerBinding<string>(Mod.MODUI, "SetDynamicHdrpComponentEnabled", SetDynamicHdrpComponentEnabled));
+            AddBinding(new TriggerBinding<string>(Mod.MODUI, "SetDynamicHdrpComponentValue", SetDynamicHdrpComponentValue));
+        }
+
+        private static string GetDynamicHdrpMetadata()
+        {
+            return RenderEffectsSystem.Instance?.GetDynamicHdrpMetadataJson() ?? "[]";
+        }
+
+        private static string GetDynamicHdrpState()
+        {
+            return RenderEffectsSystem.Instance?.GetDynamicHdrpStateJson() ?? "[]";
+        }
+
+        private static void SetDynamicHdrpComponentEnabled(string payload)
+        {
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return;
+            }
+
+            string[] parts = payload.Split('|');
+            if (parts.Length != 2)
+            {
+                return;
+            }
+
+            bool enabled = parts[1] == "1" || string.Equals(parts[1], "true", StringComparison.OrdinalIgnoreCase);
+            RenderEffectsSystem.Instance?.SetDynamicHdrpComponentEnabled(parts[0], enabled);
+        }
+
+        private static void SetDynamicHdrpComponentValue(string payload)
+        {
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return;
+            }
+
+            string[] parts = payload.Split('|');
+            if (parts.Length != 3)
+            {
+                return;
+            }
+
+            RenderEffectsSystem.Instance?.SetDynamicHdrpComponentValue(parts[0], parts[1], parts[2]);
         }
 
         private void AddSupportBindings()


### PR DESCRIPTION
### Motivation

- Make HDRP integration modular so individual post-processing components can be enabled/disabled and updated at runtime via data-driven descriptors.  
- Provide a single runtime registry and apply loop so changes are immediate without restarting the game.  
- Expose serialized metadata/state to the UI and add a generic Unity↔UI communication path for dynamic control.  
- Persist user-enabled component sets so dynamic selections survive reloads.

### Description

- Added a dynamic HDRP subsystem under `Systems/DynamicHdrp` consisting of `DynamicHdrpContracts.cs`, `DynamicHdrpModules.cs`, and `DynamicHdrpRegistry.cs` that define component/property descriptors, JSON serialization helpers, pluggable module implementations, and a runtime registry.  
- Implemented pluggable modules for Color Adjustments, White Balance, and Shadows/Midtones/Highlights using a shared `IDynamicHdrpComponentModule` interface and `DynamicHdrpComponentModuleBase<T>` with generic read/write registration and `Apply` semantics.  
- Integrated the registry into `RenderEffectsSystem` by adding `Instance`, initializing `DynamicHdrpRegistry` during `ConvertToHDRP`, calling `m_DynamicHdrpRegistry.Apply(...)` in `OnUpdate`, and exposing runtime APIs `GetDynamicHdrpMetadataJson`, `GetDynamicHdrpStateJson`, `SetDynamicHdrpComponentEnabled`, and `SetDynamicHdrpComponentValue`.  
- Extended persistence in `XML/GlobalVariables.cs` with a `DynamicComponentState` XML-backed array and helper methods `GetDynamicComponentState`/`SetDynamicComponentState` to remember component enablement across runs.  
- Added UI bindings in `Systems/UISystem.cs` to expose `DynamicHdrpMetadata` and `DynamicHdrpState` to the frontend and to accept `SetDynamicHdrpComponentEnabled` and `SetDynamicHdrpComponentValue` trigger payloads.  
- Implemented a runtime-driven TSX control surface in `Lumina/src/mods/panel.tsx` that binds to `DynamicHdrpMetadata`/`DynamicHdrpState`, dynamically renders components and their properties (float sliders and bool toggles), and immediately sends updates to Unity using the new generic trigger payloads.

### Testing

- Ran TypeScript type-check: `npx tsc --noEmit` in `Lumina/` succeeded.  
- Attempted `npm run build` in `Lumina/` but it failed in this environment because `CSII_USERDATAPATH` is not set, which prevents bundling (failure unrelated to code correctness).  
- A Playwright screenshot attempt to validate a running UI failed because no local UI server was available (`ERR_EMPTY_RESPONSE`), so live end-to-end UI rendering could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d7872a264832e872ea47326d05d30)